### PR TITLE
Drop microsender, add retransmit via receiver signal to parent task o…

### DIFF
--- a/wrath/__main__.py
+++ b/wrath/__main__.py
@@ -18,11 +18,10 @@ async def runner(func, portals, target, batch, workers=4):
 
 
 @contextlib.asynccontextmanager
-async def create_portals(workers=4):
+async def open_actor_cluster(workers=4) -> list[tractor.Portal]:
+
+    portals = []
     async with tractor.open_nursery() as tn:
-
-        portals = []
-
         for i in range(workers):
             portals.append(
                 await tn.start_actor(
@@ -32,26 +31,38 @@ async def create_portals(workers=4):
             )
 
         portals.append(await tn.start_actor('recv_from_receiver', enable_modules=['wrath.core']))
-                
-        yield portals
-        
+        yield tn, portals
         await tn.cancel()
- 
+
 
 # print('dbg! main: defined status dict')
 # print('dbg! main: defining recv_from_receiver')
-async def recv_from_receiver(stream, status, task_status=trio.TASK_STATUS_IGNORED):
-    packets_received = 0
-    # print('dbg! recv_from_receiver: inside')
-    task_status.started()
-    #print('dbg! recv_from_receiver: task_status.started()')
-    async for port in stream:
-        packets_received += 1
-        print('packets received: %d' % packets_received)
-        # print('dbg! recv_from_receiver: got a port %d' % port)
-        status[port]['recv'] = True
-        # print('dbg! recv_from_receiver: exiting %d' % port)
+_maybe_retransmit = trio.Event()
 
+async def recv_from_receiver(
+    portal,
+    status,
+    task_status=trio.TASK_STATUS_IGNORED,
+):
+    global _maybe_retransmit
+
+    async with portal.open_stream_from(receiver, target=target) as recv_stream:
+        packets_received = 0
+        # print('dbg! recv_from_receiver: inside')
+        task_status.started()
+        #print('dbg! recv_from_receiver: task_status.started()')
+        # while status:
+        # async for port in recv_stream:
+        while True:
+            with trio.move_on_after(0.69) as cs:
+                # we exit here when this task is cancelled by the parent
+                port = await recv_stream.receive()
+                _maybe_retransmit.set()
+                packets_received += 1
+                print('packets received: %d' % packets_received)
+                # print('dbg! recv_from_receiver: got a port %d' % port)
+                status[port]['recv'] = True
+                # print('dbg! recv_from_receiver: exiting %d' % port)
 
 
 async def main(target, intervals, workers=4) -> None:
@@ -63,40 +74,79 @@ async def main(target, intervals, workers=4) -> None:
     }
 
     # print('dbg! main: in front of big async with')
-    async with (
-        trio.open_nursery() as nursery,
 
-        create_portals() as portals,
+    async with open_actor_cluster() as (tn, portals):
+        async with (
 
-        portals[0].open_context(batchworker, target=target) as (ctx0, _),
-        portals[1].open_context(batchworker, target=target) as (ctx1, _),
-        portals[2].open_context(batchworker, target=target) as (ctx2, _),
-        portals[3].open_context(batchworker, target=target) as (ctx3, _),
+            portals[0].open_context(batchworker, target=target) as (ctx0, _),
+            portals[1].open_context(batchworker, target=target) as (ctx1, _),
+            portals[2].open_context(batchworker, target=target) as (ctx2, _),
+            portals[3].open_context(batchworker, target=target) as (ctx3, _),
 
-        ctx0.open_stream() as stream0,
-        ctx1.open_stream() as stream1,
-        ctx2.open_stream() as stream2,
-        ctx3.open_stream() as stream3,
+            ctx0.open_stream() as stream0,
+            ctx1.open_stream() as stream1,
+            ctx2.open_stream() as stream2,
+            ctx3.open_stream() as stream3,
 
 
-        portals[4].open_stream_from(receiver, target=target) as recv_stream,
-    ):
-        streams = [stream0, stream1, stream2, stream3]
-        # print('dbg! main: inside big async with')
-        # print('dbg! main: starting recv_from_receiver')
-        await nursery.start(recv_from_receiver, recv_stream, status)
-        # print('dbg! main: started recv_from_receiver')
-        while True:
-            # print('dbg! main: inside while True loop')
-            ports = [port for port, info in status.items() if not info['recv']]
-            print(not ports)
-            if not ports:
-                break
-                # print('dbg! main: inside while True loop, no ports, breaking'
-            for batch, stream in zip(more_itertools.sliced(ports, len(ports) // workers), itertools.cycle(streams)):
-                # print('dbg! main: inside while True loop, insider for loop, sending to stream')
-                await stream.send(batch)
-    print('dbg! main: after big async with')
+        ):
+            global _maybe_retransmit
+            streams = [stream0, stream1, stream2, stream3]
+            async with trio.open_nursery() as nursery:
+                await nursery.start(
+                    recv_from_receiver,
+                    portals[4],
+                    status,
+                )
+
+                # first cycle of batch sends
+                ports = [port for port, info in status.items() if not info['recv']]
+
+                async def send_batches(ps):
+                    for batch, stream in zip(
+                        more_itertools.sliced(ps, len(ps) // workers),
+                        itertools.cycle(streams)
+                    ):
+                        # print('dbg! main: inside while True loop, insider for loop, sending to stream')
+                        await stream.send(batch)
+
+                await send_batches(ports)
+
+                # wait for receiver to tell us it hit a delay in receiving packets
+                await _maybe_retransmit.wait()
+                _maybe_retransmit = trio.Event()
+
+                # re-transmit loop
+                repeats = 0
+                last_ports = ports = [port for port, info in status.items() if not info['recv']]
+                while True:
+                    _maybe_retransmit = trio.Event()
+                    await send_batches(ports)
+                    await _maybe_retransmit.wait()
+
+                    ports = [port for port, info in status.items() if not info['recv']]
+                    print(f'remaining ports: {ports}')
+
+                    if not ports:
+                        print('we dun, all portz scanned')
+                        break
+
+                    if ports == last_ports:
+                        print('ports were same as last re-transmitty')
+                        if repeats > 2:
+                            print(f'these ports failed bruv: {ports}')
+                            break
+
+                        repeats += 1
+
+                    last_ports = ports
+
+                # tear down the receiver task
+                print('all ports were scanned bby, u win')
+                nursery.cancel_scope.cancel()
+
+                await tn.cancel()
+
 
 if __name__ == '__main__':
     target, intervals, ports = parse_args()

--- a/wrath/core.py
+++ b/wrath/core.py
@@ -30,30 +30,35 @@ async def batchworker(ctx: tractor.Context, target):
     await ctx.started()
     # print('dbg! batchworker: inside')
     async with (
-        tractor.open_nursery() as tn,
+        # tractor.open_nursery() as tn,
         ctx.open_stream() as parent_stream,
     ):
         # print('dbg! batchworker: starting streamer actor')
-        p = await tn.start_actor('streamer {}'.format(__import__('random').randint(0, 100)), enable_modules=[__name__])
+        # p = await tn.start_actor('streamer {}'.format(__import__('random').randint(0, 100)), enable_modules=[__name__])
         # print('dbg! batchworker: started streamer actor')
         # print('dbg! batchworker: opening parent stream')
         # print('dbg! batchworker: about to loop over parent stream')
     
-        async with (
-                p.open_context(
-                    microsender,
-                    target=target,
-                ) as (ctx2, _),
+        # async with (
+        #         p.open_context(
+        #             microsender,
+        #             target=target,
+        #         ) as (ctx2, _),
 
-                ctx2.open_stream() as stream,
-            ):
+        #         ctx2.open_stream() as stream,
+        #     ):
             # print('dbg! batchworker: opened parent stream')
+            ipv4_packet = build_ipv4_packet(target)
+            send_sock = create_send_sock()
+
             async for batch in parent_stream:
             # print('dbg! batchworker: inside async for loop, opening stream to microsender')
                 # print('dbg! batchworker: inside async for loop, opened stream to microsender, about to send ports to microsender stream')
                 for port in batch:
                     # print('dbg! batchworker: inside async for loop, opened stream to microsender, sending port %d to stream' % port)
-                    await stream.send(port)       
+                    # await stream.send(port)       
+                    tcp_packet = build_tcp_packet(target, port)
+                    await send_sock.sendto(ipv4_packet + tcp_packet, (target, port))
 
 
 async def receiver(target, task_status=trio.TASK_STATUS_IGNORED):
@@ -80,5 +85,3 @@ async def receiver(target, task_status=trio.TASK_STATUS_IGNORED):
         elif flags == 20:
             print('port %d: closed' % src)
             yield src
-
-


### PR DESCRIPTION
Ok so a few things.

The main issues were:
- sticking the `Portal.open_stream_from()` in the same `async with` as everything else
  -  because you weren't blocking on the receiver task in the parent, the receiver `recv_stream` was being prematurely closed on the `__aexit__()` of `.open_stream_from()` and this was triggering downstream cancellation of all other actors in your cluster
- you want your receiver task to terminate *before* you start tearing down the cluster so that you don't get the strange race conditions with connection errors and what not we were seeing as per [the tracebacks](https://termbin.com/uv3p0)

More to do 😎,
- async spawn the actor cluster (will need some helpers in tractor for this)
- consider doing the packet receive in each worker, meaning you have multiple receive sockets but you'll know sooner which ports weren't receive based on a static timeout in each actor that is polled in parallel
- (obviously) generalize the stream connection setup to not be hard coded 😂 

-----
Results:
best times for me were like `1.44s user 0.17s system 91% cpu 1.755 total` using:
`time sudo python -m wrath <lanip> -p 0-128 -b 32`

it could get as slow as 10s depending on the lan.
also, might be worth using a dynamic timeout ("QoS" style) based on previous arrival rates of packets for the receiver timeout.